### PR TITLE
Support folder torrents by renaming all files

### DIFF
--- a/main.go
+++ b/main.go
@@ -219,7 +219,7 @@ func main() {
 			}
 		}
 		for i := range renamePlans {
-			renamePlans[i].NewPath = path.Join(fmt.Sprintf("Season %d", renamePlans[i].Season), renamePlans[i].NewFileName)
+			renamePlans[i].NewPath = filepath.Join(fmt.Sprintf("Season %d", renamePlans[i].Season), renamePlans[i].NewFileName)
 		}
 	}
 

--- a/main.go
+++ b/main.go
@@ -170,6 +170,7 @@ func main() {
 			return
 		}
 		if result.Season <= 0 {
+			log.Printf("Invalid season parsed for %s: got %d, defaulting to 1\n", tf.Name, result.Season)
 			result.Season = 1
 		}
 		if result.Episode <= 0 {


### PR DESCRIPTION
## Summary
- add helpers for enumerating torrent files and recording rename plans
- query the LLM for each video file in a torrent and build per-file rename targets
- move torrents to the appropriate library location and rename every file while handling multi-season batches

## Testing
- go build ./... *(fails: requires downloading Go modules in this offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e64019c38083258c86b3254fbf87e6